### PR TITLE
Expose methods for browser emulators

### DIFF
--- a/Resources/Themes/Frontend/BootstrapBare/frontend/_public/src/js/swbt.helper.js
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/_public/src/js/swbt.helper.js
@@ -168,3 +168,8 @@ function applyMoveHelper() {
         $elementToMoveBack.removeClass('moved').detach().appendTo('[data-moved-to="' + destination + '"]');
     });
 }
+
+// Expose methods for browser emulators
+window.safeUrl = safeUrl;
+window.cartRefresh = cartRefresh;
+window.applyMoveHelper = applyMoveHelper;


### PR DESCRIPTION
This is needed for compiling the Javascript with Webpack. Otherwise we get an "Uncaught ReferenceError: ... is not defined" wherever these methods are called.