### PR TITLE
Hide sidemenu on page load in mobile view

### DIFF
--- a/Resources/Themes/Frontend/BootstrapBare/frontend/_public/src/js/jquery.off-canvas-menu-extend.js
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/_public/src/js/jquery.off-canvas-menu-extend.js
@@ -17,7 +17,8 @@ $.overridePlugin('swOffcanvasMenu', {
         'disableTransitions': false,
         'disableTransitionCls': 'no-transitions',
         'mode': 'local',
-        'ajaxURL': ''
+        'ajaxURL': '',
+        'hideOnPageLoadCls': 'hide-on-page-load'
     },
 
     /**
@@ -31,6 +32,8 @@ $.overridePlugin('swOffcanvasMenu', {
         var me = this,
             opts = me.opts,
             menuWidth = me.$offCanvas.outerWidth();
+
+        me.$offCanvas.removeClass(opts.hideOnPageLoadCls);
 
         if (me.isOpened) {
             return;

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/_public/src/less/_components/offcanvas.less
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/_public/src/less/_components/offcanvas.less
@@ -103,8 +103,6 @@
 }
 
 // fixes: menu panels in an offcanvas are no longer visible for a short time on page load
-@media (max-width: @screen-sm-max) {
-    .offcanvas-has-panel:not(.is-active) .panel {
-        display: none;
-    }
+.offcanvas-has-panel.hide-on-page-load{
+    display:none;
 }

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/account/sidebar.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/account/sidebar.tpl
@@ -15,7 +15,7 @@
                     {/block}
                 {/if}
                 {block name="frontend_account_offcanvas_wrapper"}
-                    <div id="accountSidebar" class="account-offcanvas offcanvas-has-panel">
+                    <div id="accountSidebar" class="account-offcanvas offcanvas-has-panel hide-on-page-load">
                         <div class="account-menu panel panel-default{if {config name=useSltCookie} && $userInfo && $inHeader} mbn{/if}">
                             {* Sidebar navigation headline *}
                             {block name="frontend_account_menu_title"}


### PR DESCRIPTION
This fixed a problem with mobile menu on page load. While browsing the shopware installation with mobile devices, one of the sidemenus appeard shortly on page load. The sidemenu moves left out of screen.