### PR TITLE
Fix compiling error with activated stripe plugin

### DIFF
--- a/Resources/Themes/Frontend/BootstrapBare/frontend/_public/src/less/_modules/swf-general.less
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/_public/src/less/_modules/swf-general.less
@@ -358,3 +358,6 @@ input.pwd-show-hide {
         outline: none;
     }
 }
+
+.is--align-center { text-align: center !important; }
+


### PR DESCRIPTION
Fix #20 by adding .is--align-center class to general less file in
BootstrapBare folder.