### PR TITLE
Add (Bare) document templates

### DIFF
--- a/Resources/Themes/Frontend/BootstrapBare/documents/index.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/documents/index.tpl
@@ -1,0 +1,365 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="content-type" content="text/html; utf-8">
+<meta name="author" content=""/>
+<meta name="copyright" content="" />
+
+<title></title>
+<style type="text/css">
+{block name="document_index_css"}
+body {
+    {$Containers.Body.style}
+}
+
+div#head_logo {
+    {$Containers.Logo.style}
+}
+
+div#head_sender {
+    {$Containers.Header_Recipient.style}
+}
+
+div#header {
+    {$Containers.Header.style}
+}
+
+div#head_left {
+    {$Containers.Header_Box_Left.style}
+}
+
+div#head_right {
+    {$Containers.Header_Box_Right.style}
+}
+
+div#head_bottom {
+    {$Containers.Header_Box_Bottom.style}
+}
+
+div#content {
+    {$Containers.Content.style}
+}
+
+td {
+    {$Containers.Td.style}
+}
+
+td.name {
+    {$Containers.Td_Name.style}
+}
+
+td.line {
+    {$Containers.Td_Line.style}
+}
+
+td.head  {
+    {$Containers.Td_Head.style}
+}
+
+#footer {
+    {$Containers.Footer.style}
+}
+
+#amount {
+    {$Containers.Content_Amount.style}
+}
+
+#sender {
+    {$Containers.Header_Sender.style}
+}
+
+#info {
+    {$Containers.Content_Info.style}
+}
+{/block}
+</style>
+</head>
+
+<body>
+{block name="document_index_body"}
+{foreach from=$Pages item=positions name="pagingLoop" key=page}
+
+    {* @Deprecated: Wrong variable will be removed in next major release *}
+    {$postions = $positions}
+
+    <div id="head_logo">
+        {$Containers.Logo.value}
+    </div>
+    <div id="header">
+        {block name="document_index_head_left_wrapper"}
+            <div id="head_left">
+            {if $smarty.foreach.pagingLoop.first}
+                {block name="document_index_selectAdress"}
+                    {assign var="address" value="billing"}
+                {/block}
+                <div id="head_sender">
+                    {block name="document_index_address"}
+                        {block name="document_index_address_sender"}
+                            <p class="sender">{$Containers.Header_Sender.value}</p>
+                        {/block}
+                        {block name="document_index_address_base"}
+                            {if $User.$address.company}{$User.$address.company}<br />{/if}
+                            {if $User.$address.department}{$User.$address.department}<br />{/if}
+                            {$User.$address.salutation|salutation}
+                            {if {config name="displayprofiletitle"}}
+                                {$User.$address.title}<br/>
+                            {/if}
+                            {$User.$address.firstname} {$User.$address.lastname}<br />
+                            {$User.$address.street}<br />
+                        {/block}
+                        {block name="document_index_address_additionalAddressLines"}
+                            {if {config name=showAdditionAddressLine1}}
+                                {$User.$address.additional_address_line1}<br />
+                            {/if}
+                            {if {config name=showAdditionAddressLine2}}
+                                {$User.$address.additional_address_line2}<br />
+                            {/if}
+                        {/block}
+                        {block name="document_index_address_cityZip"}
+                            {if {config name=showZipBeforeCity}}
+                                {$User.$address.zipcode} {$User.$address.city}<br />
+                            {else}
+                                {$User.$address.city} {$User.$address.zipcode}<br />
+                            {/if}
+                        {/block}
+                        {block name="document_index_address_countryData"}
+                            {if $User.$address.state.shortcode}{$User.$address.state.shortcode} - {/if}{$User.$address.country.countryen}<br />
+                        {/block}
+                    {/block}
+                </div>
+            {/if}
+            </div>
+        {/block}
+        {block name="document_index_head_right_wrapper"}
+            <div id="head_right">
+                    <strong>
+                    {block name="document_index_head_right"}
+                        {$Containers.Header_Box_Right.value}
+                        {s name="DocumentIndexCustomerID"}{/s} {$User.billing.customernumber|string_format:"%06d"}<br />
+                        {if $User.billing.ustid}
+                        {s name="DocumentIndexUstID"}{/s} {$User.billing.ustid|replace:" ":""|replace:"-":""}<br />
+                        {/if}
+                        {s name="DocumentIndexOrderID"}{/s} {$Order._order.ordernumber}<br />
+                        {s name="DocumentIndexDate"}{/s} {$Document.date}<br />
+                        {if $Document.deliveryDate}{s name="DocumentIndexDeliveryDate"}{/s} {$Document.deliveryDate}<br />{/if}
+                    {/block}
+                    </strong>
+            </div>
+        {/block}
+    </div>
+
+    {block name="document_index_head_bottom_wrapper"}
+        <div id="head_bottom" style="clear:both">
+            {block name="document_index_head_bottom"}
+                <h1>{s name="DocumentIndexInvoiceNumber"}Rechnung Nr. {$Document.id}{/s}</h1>
+                {s name="DocumentIndexPageCounter"}Seite {$page+1} von {$Pages|@count}{/s}
+             {/block}
+        </div>
+    {/block}
+
+    <div id="content">
+        {block name="document_index_table_header"}
+            <table cellpadding="0" cellspacing="0" width="100%">
+            <tbody valign="top">
+            <tr>
+                {block name="document_index_table_head_pos"}
+                    <td align="left" width="5%" class="head">
+                        <strong>{s name="DocumentIndexHeadPosition"}{/s}</strong>
+                    </td>
+                {/block}
+                {block name="document_index_table_head_nr"}
+                    <td align="left" width="10%" class="head">
+                        <strong>{s name="DocumentIndexHeadArticleID"}{/s}</strong>
+                    </td>
+                {/block}
+                {block name="document_index_table_head_name"}
+                    <td align="left" width="48%" class="head">
+                        <strong>{s name="DocumentIndexHeadName"}{/s}</strong>
+                    </td>
+                {/block}
+                {block name="document_index_table_head_quantity"}
+                    <td align="right" width="5%" class="head">
+                        <strong>{s name="DocumentIndexHeadQuantity"}{/s}</strong>
+                    </td>
+                {/block}
+                {block name="document_index_table_head_tax"}
+                    {if $Document.netto != true}
+                        <td align="right" width="6%" class="head">
+                            <strong>{s name="DocumentIndexHeadTax"}{/s}</strong>
+                        </td>
+                    {/if}
+                {/block}
+                {block name="document_index_table_head_price"}
+                    {if $Document.netto != true && $Document.nettoPositions != true}
+                        <td align="right" width="10%" class="head">
+                            <strong>{s name="DocumentIndexHeadPrice"}{/s}</strong>
+                        </td>
+                        <td align="right" width="12%" class="head">
+                            <strong>{s name="DocumentIndexHeadAmount"}{/s}</strong>
+                        </td>
+                    {else}
+                         <td align="right" width="10%" class="head">
+                            <strong>{s name="DocumentIndexHeadNet"}{/s}</strong>
+                         </td>
+                         <td align="right" width="12%" class="head">
+                            <strong>{s name="DocumentIndexHeadNetAmount"}{/s}</strong>
+                         </td>
+                    {/if}
+                {/block}
+            </tr>
+        {/block}
+    {foreach from=$positions item=position key=number}
+    {block name="document_index_table_each"}
+    <tr>
+        {block name="document_index_table_pos"}
+            <td align="left" width="5%" valign="top">
+                {$number+1}
+            </td>
+        {/block}
+        {block name="document_index_table_nr"}
+            <td align="left" width="10%" valign="top">
+                {$position.articleordernumber|truncate:14:""}
+            </td>
+        {/block}
+        {block name="document_index_table_name"}
+            <td align="left" width="48%" valign="top">
+            {if $position.name == 'Versandkosten'}
+                {s name="DocumentIndexPositionNameShippingCosts"}{$position.name}{/s}
+            {else}
+                {s name="DocumentIndexPositionNameDefault"}{$position.name|nl2br|wordwrap:65:"<br />\n"}{/s}
+            {/if}
+            </td>
+        {/block}
+        {block name="document_index_table_quantity"}
+            <td align="right" width="5%" valign="top">
+                {$position.quantity}
+            </td>
+        {/block}
+        {block name="document_index_table_tax"}
+            {if $Document.netto != true}
+                <td align="right" width="6%" valign="top">
+                    {$position.tax} %
+                </td>
+            {/if}
+        {/block}
+        {block name="document_index_table_price"}
+            {if $Document.netto != true && $Document.nettoPositions != true}
+                <td align="right" width="10%" valign="top">
+                    {$position.price|currency}
+                </td>
+                <td align="right" width="12%" valign="top">
+                    {$position.amount|currency}
+                </td>
+            {else}
+                <td align="right" width="10%" valign="top">
+                    {$position.netto|currency}
+                </td>
+                <td align="right" width="12%" valign="top">
+                    {$position.amount_netto|currency}
+                </td>
+            {/if}
+        {/block}
+    </tr>
+    {/block}
+    {/foreach}
+    </tbody>
+    </table>
+    </div>
+
+    {if $smarty.foreach.pagingLoop.last}
+        {block name="document_index_amount"}
+            <div id="amount">
+              <table width="300px" cellpadding="0" cellspacing="0">
+              <tbody>
+              <tr>
+                <td align="right" width="100px" class="head">{s name="DocumentIndexTotalNet"}{/s}</td>
+                <td align="right" width="200px" class="head">{$Order._amountNetto|currency}</td>
+              </tr>
+              {if $Document.netto == false}
+                  {foreach from=$Order._tax key=key item=tax}
+                  <tr>
+                    <td align="right">{s name="DocumentIndexTax"}zzgl. {$key|tax}{/s}</td>
+                    <td align="right">{$tax|currency}</td>
+                  </tr>
+                  {/foreach}
+              {/if}
+              {if $Document.netto == false}
+                  <tr>
+                    <td align="right"><b>{s name="DocumentIndexTotal"}{/s}</b></td>
+                    <td align="right"><b>{$Order._amount|currency}</b></td>
+                  </tr>
+              {else}
+                  <tr>
+                    <td align="right"><b>{s name="DocumentIndexTotal"}{/s}</b></td>
+                    <td align="right"><b>{$Order._amountNetto|currency}</b></td>
+                  </tr>
+              {/if}
+              </tbody>
+              </table>
+            </div>
+        {/block}
+        {block name="document_index_info"}
+            <div id="info">
+            {block name="document_index_info_comment"}
+                {if $Document.comment}
+                    <div style="font-size:11px;color:#333;font-weight:bold">
+                        {$Document.comment|replace:"€":"&euro;"}
+                    </div>
+                {/if}
+            {/block}
+            {block name="document_index_info_net"}
+                {if $Document.netto == true}
+                <p>{s name="DocumentIndexAdviceNet"}{/s}</p>
+                {/if}
+                <p>{s name="DocumentIndexSelectedPayment"}{/s} {$Order._payment.description}</p>
+            {/block}
+            {block name="document_index_info_voucher"}
+                {if $Document.voucher}
+                    <div style="font-size:11px;color:#333;">
+                    {s name="DocumentIndexVoucher"}
+                        Für den nächsten Einkauf schenken wir Ihnen einen {$Document.voucher.value} {$Document.voucher.prefix} Gutschein
+                        mit dem Code "{$Document.voucher.code}".<br />
+                    {/s}
+                    </div>
+                {/if}
+            {/block}
+            {block name="document_index_info_ordercomment"}
+                {if $Order._order.customercomment}
+                    <div style="font-size:11px;color:#333;">
+                        {s name="DocumentIndexComment"}{/s}
+                        {$Order._order.customercomment|replace:"€":"&euro;"}
+                    </div>
+                {/if}
+            {/block}
+            {block name="document_index_info_dispatch"}
+                {if $Order._dispatch.name}
+                    <p>
+                        {s name="DocumentIndexSelectedDispatch"}{/s}
+                        {$Order._dispatch.name}
+                    </p>
+                {/if}
+            {/block}
+
+                {$Containers.Content_Info.value}
+            {block name="document_index_info_currency"}
+                {if $Order._currency.factor != 1}{s name="DocumentIndexCurrency"}
+                    <br>Euro Umrechnungsfaktor: {$Order._currency.factor|replace:".":","}
+                    {/s}
+                {/if}
+            {/block}
+            </div>
+        {/block}
+    {/if}
+
+    {block name="document_index_footer"}
+        <div id="footer">
+        {$Containers.Footer.value}
+        </div>
+        {if !$smarty.foreach.pagingLoop.last}
+            <pagebreak />
+        {/if}
+    {/block}
+{/foreach}
+{/block}
+</body>
+</html>

--- a/Resources/Themes/Frontend/BootstrapBare/documents/index_gs.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/documents/index_gs.tpl
@@ -1,0 +1,9 @@
+{extends file="documents/index.tpl"}
+{block name="document_index_head_bottom"}
+    <h1>{s name="DocumentIndexCreditNumber"}{/s} {$Document.id}</h1>
+    {s name="DocumentIndexPageCounter"}Seite {$page+1} von {$Pages|@count}{/s}
+{/block}
+{block name="document_index_head_right"}
+    {$smarty.block.parent}
+    {if $Document.bid}{s name="DocumentIndexInvoiceID"}{/s} {$Document.bid}<br />{/if}
+{/block}

--- a/Resources/Themes/Frontend/BootstrapBare/documents/index_ls.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/documents/index_ls.tpl
@@ -1,0 +1,25 @@
+{extends file="documents/index.tpl"}
+
+{block name="document_index_table_head_tax"}
+{/block}
+{block name="document_index_table_head_price"}
+{/block}
+{block name="document_index_table_tax"}
+{/block}
+{block name="document_index_table_price"}
+{/block}
+{block name="document_index_amount"}
+{/block}
+
+{block name="document_index_head_bottom"}
+    <h1>{s name="DocumentIndexShippingNumber"}{/s} {$Document.id}</h1>
+    {s name="DocumentIndexPageCounter"}{/s}
+{/block}
+{block name="document_index_selectAdress"}
+    {assign var="address" value="shipping"}
+{/block}
+{block name="document_index_table_each"}{if $position.modus == 0 || $position.modus == 1}{$smarty.block.parent}{/if}{/block}
+{block name="document_index_head_right"}
+    {$smarty.block.parent}
+    {if $Document.bid}{s name="DocumentIndexInvoiceID"}{/s} {$Document.bid}<br />{/if}
+{/block}

--- a/Resources/Themes/Frontend/BootstrapBare/documents/index_sr.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/documents/index_sr.tpl
@@ -1,0 +1,55 @@
+{extends file="documents/index.tpl"}
+
+{block name="document_index_table_price"}
+    {if $Document.netto != true && $Document.nettoPositions != true}
+        <td align="right" width="10%">
+            {($position.price*-1)|currency}
+        </td>
+        <td align="right" width="12%">
+            {($position.amount*-1)|currency}
+        </td>
+    {else}
+        <td align="right" width="10%">
+            {($position.netto*-1)|currency}
+        </td>
+        <td align="right" width="12%">
+            {($position.amount_netto*-1)|currency}
+        </td>
+    {/if}
+{/block}
+{block name="document_index_amount"}
+<div id="amount">
+      <table width="300px" cellpadding="0" cellspacing="0">
+      <tbody>
+      <tr>
+        <td align="right" width="100px" class="head">{s name="DocumentIndexTotalNet"}{/s}</td>
+        <td align="right" width="200px" class="head">-{$Order._amountNetto|currency}</td>
+      </tr>
+      {if $Document.netto == false}
+          {foreach from=$Order._tax key=key item=tax}
+          <tr>
+            <td align="right">{s name="DocumentIndexTax"}{/s}</td>
+            <td align="right">-{$tax|currency}</td>
+          </tr>
+          {/foreach}
+      {/if}
+      {if $Document.netto == false}
+          <tr>
+            <td align="right"><b>{s name="DocumentIndexTotal"}{/s}</b></td>
+            <td align="right"><b>-{$Order._amount|currency}</b></td>
+          </tr>
+      {else}
+          <tr>
+            <td align="right"><b>{s name="DocumentIndexTotal"}{/s}</b></td>
+            <td align="right"><b>-{$Order._amountNetto|currency}</b></td>
+          </tr>
+      {/if}
+      </tbody>
+      </table>
+</div>
+{/block}
+
+{block name="document_index_head_bottom"}
+    <h1>{s name="DocumentIndexCancelationNumber"}{/s}</h1>
+    {s name="DocumentIndexPageCounter"}{/s}
+{/block}

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/_includes/privacy.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/_includes/privacy.tpl
@@ -1,0 +1,16 @@
+{block name="frontend_data_protection_information"}
+    <p class="privacy-information">
+        {if {config name=ACTDPRCHECK} && !$hideCheckbox}
+            {block name="frontend_data_protection_information_checkbox"}
+                <input name="privacy-checkbox" type="checkbox" id="privacy-checkbox" required="required" aria-required="true" value="1" class="is--required"{if $smarty.post['privacy-checkbox']} checked{/if} />
+                <label for="privacy-checkbox">
+                    {s name="PrivacyText" namespace="frontend/index/privacy"}{/s}
+                </label>
+            {/block}
+        {elseif {config name=ACTDPRTEXT}}
+            {block name="frontend_data_protection_information_text"}
+                {s name="PrivacyText" namespace="frontend/index/privacy"}{/s}
+            {/block}
+        {/if}
+    </p>
+{/block}

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/_includes/privacy.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/_includes/privacy.tpl
@@ -2,8 +2,8 @@
     <p class="privacy-information">
         {if {config name=ACTDPRCHECK} && !$hideCheckbox}
             {block name="frontend_data_protection_information_checkbox"}
-                <input name="privacy-checkbox" type="checkbox" id="privacy-checkbox" required="required" aria-required="true" value="1" class="is--required"{if $smarty.post['privacy-checkbox']} checked{/if} />
                 <label for="privacy-checkbox">
+                    <input name="privacy-checkbox" type="checkbox" id="privacy-checkbox" required="required" aria-required="true" value="1" class="is--required"{if $smarty.post['privacy-checkbox']} checked{/if} />
                     {s name="PrivacyText" namespace="frontend/index/privacy"}{/s}
                 </label>
             {/block}

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/blog/comment/form.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/blog/comment/form.tpl
@@ -111,6 +111,13 @@
                 </div>
             {/block}
 
+            {* Data protection information *}
+            {block name='frontend_forms_form_elements_form_privacy'}
+                {if {config name=ACTDPRTEXT} || {config name=ACTDPRCHECK}}
+                    {include file="frontend/_includes/privacy.tpl"}
+                {/if}
+            {/block}
+
             {* Submit button *}
             {block name='frontend_blog_comments_input_submit'}
                 <div class="form-group">

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/custom/index.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/custom/index.tpl
@@ -31,7 +31,11 @@
         <ul class="nav nav-tabs">
             {foreach $pages as $subPage}
                 <li{if $subPage.active} class="active"{/if}>
-                    <a href="{url controller=custom sCustom=$subPage.id}" title="{$subPage.description}">{$subPage.description}</a>
+                    <a href="{if $subPage.link}{$subPage.link}{else}{url controller='custom' sCustom=$subPage.id title=$subPage.description}{/if}"
+                    title="{$subPage.description}"
+                    data-categoryId="{$subPage.id}"
+                    data-fetchUrl="{url module=widgets controller=listing action=getCustomPage pageId={$subPage.id}}"
+                    {if $subPage.target}target="{$subPage.target}"{/if}>{$subPage.description}</a>
                 </li>
             {/foreach}
         </ul>

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/detail/comment/form.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/detail/comment/form.tpl
@@ -130,6 +130,13 @@
             </div>
         {/block}
 
+        {* Data protection information *}
+        {block name='frontend_forms_form_elements_form_privacy'}
+            {if {config name=ACTDPRTEXT} || {config name=ACTDPRCHECK}}
+                {include file="frontend/_includes/privacy.tpl"}
+            {/if}
+        {/block}
+
         {* Review actions *}
         {block name='frontend_detail_comment_input_actions'}
             <div class="form-group">

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/detail/tabs/description.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/detail/tabs/description.tpl
@@ -37,6 +37,14 @@
     </div>
 {/block}
 
+{* Supplier *}
+{block name='frontend_detail_description_supplier'}
+    {if $sArticle.supplierDescription}
+        <h3>{s name="DetailDescriptionSupplier"}{/s} "{$sArticle.supplierName}"</h3>
+        <p>{$sArticle.supplierDescription}</p>
+    {/if}
+{/block}
+
 {* Links *}
 {block name='frontend_detail_description_links'}
     {if $sArticle.sLinks}
@@ -56,14 +64,6 @@
                 </li>
             {/foreach}
         </ul>
-    {/if}
-{/block}
-
-{* Supplier *}
-{block name='frontend_detail_description_supplier'}
-    {if $sArticle.supplierDescription}
-        <h3>{s name="DetailDescriptionSupplier"}{/s} "{$sArticle.supplierName}"</h3>
-        <p>{$sArticle.supplierDescription}</p>
     {/if}
 {/block}
 

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/forms/form-elements.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/forms/form-elements.tpl
@@ -3,30 +3,11 @@
 {block name='frontend_forms_form_elements'}
     {capture name="formlabel"}<label class="control-label {$FormLabelSize}" {/capture}
     <form id="support" name="support" class="{$sSupport.class} form-horizontal" method="post"
-          action="{url controller='ticket' action='index' id=$id}" enctype="multipart/form-data">
+        action="{url action='index' id=$id}" enctype="multipart/form-data">
         <input type="hidden" name="forceMail" value="{$forceMail|escape}">
 
         {* Form Content *}
         {block name='frontend_forms_form_elements_form_content'}
-            {if $sSupport.sErrors.e || $sSupport.sErrors.v}
-                <div class="alert alert-danger">
-                    {if $sSupport.sErrors.v}
-                        {foreach from=$sSupport.sErrors.v key=sKey item=sError}
-                            {if $sKey !=0&&$sSupport.sElements.$sError.error_msg}<br/>{/if}
-                            {$sSupport.sElements.$sError.error_msg}
-                        {/foreach}
-                        {if $sSupport.sErrors.e}<br/>{/if}
-                    {/if}
-                    {if $sSupport.sErrors.e}
-                        {if $sSupport.sErrors.e['sCaptcha'] == true}
-                            {$errorContent="{$errorContent}{s name='SupportInfoFillCaptcha' namespace="frontend/forms/elements"}{/s}"}
-                        {else}
-                            {s name='SupportInfoFillRedFields'}{/s}
-                        {/if}
-                    {/if}
-                </div>
-            {/if}
-
             <fieldset>
                 {block name='frontend_forms_form_elements_form_builder'}
                     {foreach from=$sSupport.sElements item=sElement key=sKey}
@@ -86,18 +67,14 @@
                         {/if}
                     {/foreach}
                 {/block}
-
+                
                 {* Captcha *}
                 {block name='frontend_forms_elements_form_captcha'}
                     <div class="form-group{if $sSupport.sErrors.e.sCaptcha} has-error{/if} captcha">
                         <div class="{$FormLabelOffset} {$FormInputSize}">
                             <div class="row">
                                 <div class="col-xs-12">
-                                    <div class="captcha-placeholder" data-src="{url module=widgets controller=Captcha action=refreshCaptcha}"></div>
-                                </div>
-                                <div class="col-xs-12">
-                                    <p class="mtm"><small>{s name='SupportLabelCaptcha'}{/s}</small></p>
-                                    <input type="text" name="sCaptcha" class="form-control mtm is-required" required="required" aria-required="true" />
+                                    <div class="captcha-placeholder" data-src="{url module=widgets controller=Captcha action=index}"></div>
                                 </div>
                             </div>
                         </div>

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/forms/form-elements.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/forms/form-elements.tpl
@@ -104,17 +104,16 @@
                     </div>
                 {/block}
 
-                {* Data protection information *}
-                {block name='frontend_forms_form_elements_form_privacy'}
-                    {if {config name=ACTDPRTEXT} || {config name=ACTDPRCHECK}}
-                        {include file="frontend/_includes/privacy.tpl"}
-                    {/if}
-                {/block}
-
                 {* Forms actions *}
                 {block name='frontend_forms_elements_form_submit'}
                     <div class="form-group">
                         <div class="{$FormLabelOffset} {$FormInputSize}">
+                            {* Data protection information *}
+                            {block name='frontend_forms_form_elements_form_privacy'}
+                                {if {config name=ACTDPRTEXT} || {config name=ACTDPRCHECK}}
+                                    {include file="frontend/_includes/privacy.tpl"}
+                                {/if}
+                            {/block}
                             <span class="help-block required-info">{s name='SupportLabelInfoFields'}{/s}</span>
                             <input class="btn btn-primary" type="submit" name="Submit" value="{s name='SupportActionSubmit'}{/s}">
                         </div>

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/forms/form-elements.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/forms/form-elements.tpl
@@ -16,10 +16,7 @@
                             {$field = $sSupport.sFields[$sKey]|replace:'{literal}':''|replace:'{/literal}':''|replace:'%*%':"{s name='RequiredField' namespace='frontend/register/index'}{/s}"}
 
                             {if !$sSupport.sFields[$sKey]|strstr:"type=\"checkbox"}
-                                <pre>
-                                    {$sSupport.sFields[$sKey]|@print_r}
-                                </pre>
-                                <div class="form-group{if $sSupport.sFields[$sKey]|strpos:"instyle_error"} has-error{/if}">
+                                <div class="form-group{if $sSupport.sFields[$sKey]|strpos:"instyle_error"} has-error{/if}{if $sSupport.sFields[$sKey]|strstr:"type=\"hidden"} hidden{/if}">
                                     {$sSupport.sLabels.$sKey|replace:'<label ':$smarty.capture.formlabel}
                                     <div class="{$FormInputSize}">
                                         {if $field|strstr:"class=\"strasse"}

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/forms/form-elements.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/forms/form-elements.tpl
@@ -16,6 +16,9 @@
                             {$field = $sSupport.sFields[$sKey]|replace:'{literal}':''|replace:'{/literal}':''|replace:'%*%':"{s name='RequiredField' namespace='frontend/register/index'}{/s}"}
 
                             {if !$sSupport.sFields[$sKey]|strstr:"type=\"checkbox"}
+                                <pre>
+                                    {$sSupport.sFields[$sKey]|@print_r}
+                                </pre>
                                 <div class="form-group{if $sSupport.sFields[$sKey]|strpos:"instyle_error"} has-error{/if}">
                                     {$sSupport.sLabels.$sKey|replace:'<label ':$smarty.capture.formlabel}
                                     <div class="{$FormInputSize}">

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/forms/form-elements.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/forms/form-elements.tpl
@@ -104,6 +104,13 @@
                     </div>
                 {/block}
 
+                {* Data protection information *}
+                {block name='frontend_forms_form_elements_form_privacy'}
+                    {if {config name=ACTDPRTEXT} || {config name=ACTDPRCHECK}}
+                        {include file="frontend/_includes/privacy.tpl"}
+                    {/if}
+                {/block}
+
                 {* Forms actions *}
                 {block name='frontend_forms_elements_form_submit'}
                     <div class="form-group">

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/forms/index.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/forms/index.tpl
@@ -22,6 +22,36 @@
         <div class="h1">{$sSupport.name}</div>
     {/block}
 
+    {* Form error *}
+    {block name='frontend_forms_elements_error'}
+        {if $sSupport.sErrors.e || $sSupport.sErrors.v}
+            {$errorContent=""}
+            <div class="error">
+                {if $sSupport.sErrors.v}
+                    {foreach from=$sSupport.sErrors.v key=sKey item=sError}
+                        {if $sKey !=0&&$sSupport.sElements.$sError.error_msg}{$errorContent="{$errorContent}<br />"}{/if}
+                        {$errorContent="{$errorContent}{$sSupport.sElements.$sError.error_msg}"}
+                    {/foreach}
+                    {if $sSupport.sErrors.e}
+                        {$errorContent="{$errorContent}<br />"}
+                    {/if}
+                {/if}
+
+                {if $sSupport.sErrors.e}
+                    {if $sSupport.sErrors.e['sCaptcha'] == true}
+                        {$errorContent="{$errorContent}{s name='SupportInfoFillCaptcha' namespace="frontend/forms/elements"}{/s}"}
+                    {else}
+                        {$errorContent="{$errorContent}{s name='SupportInfoFillRedFields' namespace="frontend/forms/elements"}{/s}"}
+                    {/if}
+                {/if}
+
+                {block name='frontend_forms_elements_error_messages'}
+                    {include file="frontend/_includes/messages.tpl" type='error' content=$errorContent}
+                {/block}
+            </div>
+        {/if}
+    {/block}
+
     {* Forms Content *}
     {block name='frontend_forms_index_content'}
         {if $sSupport.sElements}
@@ -39,4 +69,3 @@
 
 {* Sidebar right *}
 {block name='frontend_index_content_right'}{/block}
-

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/index/footer-navigation.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/index/footer-navigation.tpl
@@ -95,21 +95,20 @@
                                                         </button>
                                                     </span>
                                                 {/block}
-                                                
-                                                {* Data protection information *}
-                                                {block name="frontend_index_footer_column_newsletter_privacy"}
-                                                    {if {config name=ACTDPRTEXT} || {config name=ACTDPRCHECK}}
-                                                        {$hideCheckbox=false}
-
-                                                        {* If a captcha is active, the user has to accept the privacy statement on the newsletter page *}
-                                                        {if {config name=newsletterCaptcha} !== "nocaptcha"}
-                                                            {$hideCheckbox=true}
-                                                        {/if}
-
-                                                        {include file="frontend/_includes/privacy.tpl" hideCheckbox=$hideCheckbox}
-                                                    {/if}
-                                                {/block}
                                             </div>
+                                            {* Data protection information *}
+                                            {block name="frontend_index_footer_column_newsletter_privacy"}
+                                                {if {config name=ACTDPRTEXT} || {config name=ACTDPRCHECK}}
+                                                    {$hideCheckbox=false}
+
+                                                    {* If a captcha is active, the user has to accept the privacy statement on the newsletter page *}
+                                                    {if {config name=newsletterCaptcha} !== "nocaptcha"}
+                                                        {$hideCheckbox=true}
+                                                    {/if}
+
+                                                    {include file="frontend/_includes/privacy.tpl" hideCheckbox=$hideCheckbox}
+                                                {/if}
+                                            {/block}
                                         {/block}
                                     </form>
                                  {/block}

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/index/footer-navigation.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/index/footer-navigation.tpl
@@ -95,6 +95,20 @@
                                                         </button>
                                                     </span>
                                                 {/block}
+                                                
+                                                {* Data protection information *}
+                                                {block name="frontend_index_footer_column_newsletter_privacy"}
+                                                    {if {config name=ACTDPRTEXT} || {config name=ACTDPRCHECK}}
+                                                        {$hideCheckbox=false}
+
+                                                        {* If a captcha is active, the user has to accept the privacy statement on the newsletter page *}
+                                                        {if {config name=newsletterCaptcha} !== "nocaptcha"}
+                                                            {$hideCheckbox=true}
+                                                        {/if}
+
+                                                        {include file="frontend/_includes/privacy.tpl" hideCheckbox=$hideCheckbox}
+                                                    {/if}
+                                                {/block}
                                             </div>
                                         {/block}
                                     </form>

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/newsletter/index.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/newsletter/index.tpl
@@ -221,17 +221,16 @@
                                 {/if}
                             {/block}
 
-                            {* Data protection information *}
-                            {block name="frontend_newsletter_form_privacy"}
-                                {if {config name=ACTDPRTEXT} || {config name=ACTDPRCHECK}}
-                                    {include file="frontend/_includes/privacy.tpl"}
-                                {/if}
-                            {/block}
-
                             {* Submit button *}
                             {block name="frontend_newsletter_form_submit"}
                                 <div class="form-group">
                                     <div class="{$FormLabelOffset} {$FormInputSize}">
+                                        {* Data protection information *}
+                                        {block name="frontend_newsletter_form_privacy"}
+                                            {if {config name=ACTDPRTEXT} || {config name=ACTDPRCHECK}}
+                                                {include file="frontend/_includes/privacy.tpl"}
+                                            {/if}
+                                        {/block}
                                         <span class="help-block required-info">{s name='RegisterPersonalRequiredText' namespace='frontend/register/personal_fieldset'}{/s}</span>
                                         <button class="btn btn-primary" type="submit" name="submit">{s name=sNewsletterButton}{/s}</button>
                                     </div>

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/newsletter/index.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/newsletter/index.tpl
@@ -221,6 +221,13 @@
                                 {/if}
                             {/block}
 
+                            {* Data protection information *}
+                            {block name="frontend_newsletter_form_privacy"}
+                                {if {config name=ACTDPRTEXT} || {config name=ACTDPRCHECK}}
+                                    {include file="frontend/_includes/privacy.tpl"}
+                                {/if}
+                            {/block}
+
                             {* Submit button *}
                             {block name="frontend_newsletter_form_submit"}
                                 <div class="form-group">

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/plugins/notification/index.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/plugins/notification/index.tpl
@@ -46,6 +46,12 @@
                                         </span>
                                     {/block}
                                 </div>
+                                {* Data protection information *}
+                                {block name="frontend_detail_index_notification_privacy"}
+                                    {if {config name=ACTDPRTEXT} || {config name=ACTDPRCHECK}}
+                                        {include file="frontend/_includes/privacy.tpl"}
+                                    {/if}
+                                {/block}
                             </form>
                         </div>
                     </div>

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/register/personal_fieldset.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/register/personal_fieldset.tpl
@@ -121,26 +121,28 @@
             {* Skip login *}
             {if !$update}
                 {block name='frontend_register_personal_fieldset_skip_login'}
-                    {if ($showNoAccount || $form_data.accountmode) && !$sEsd && !$form_data.sValidation && !{config name=NoAccountDisable}}
+                    <input type="hidden"
+                            value="0"
+                            name="register[personal][accountmode]"
+                            class="register--checkbox chkbox"/>
+                    {if !$sEsd && !$form_data.sValidation && ({config name=NoAccountDisable} == 1 || {config name=NoAccountDisable} == 2)}
+                        {$accountModeChecked = {config name=NoAccountDisable} == 1}
+                        {if isset($form_data.accountmode)}
+                            {$accountModeChecked = $form_data.accountmode}
+                        {/if}
                         <div class="form-group register-check sw5-plugin">
                             <div class="{$FormInputSize} {$FormLabelOffset}">
-                                <label for="register_personal_skipLogin" class="checkbox-inline">
-                                    <input type="checkbox" 
-                                           value="1" 
-                                           id="register_personal_skipLogin" 
-                                           name="register[personal][accountmode]" 
-                                           {if $form_data.accountmode || $accountmode}checked {/if} /> 
+                                <label for="register_personal_skipLogin"
+                                    class="checkbox-inline">
+                                    <input type="checkbox" value="1"
+                                        id="register_personal_skipLogin"
+                                        name="register[personal][accountmode]" 
+                                        {if $form_data.accountmode || $accountmode}checked{/if} />
                                     <strong>{s name='RegisterLabelNoAccount'}{/s}</strong>
                                 </label>
                             </div>
                         </div>
-                    {else}
-                        <input type="hidden"
-                               value="0"
-                               id="register_personal_skipLogin"
-                               name="register[personal][accountmode]"
-                               {if $form_data.accountmode || $accountmode}checked="checked" {/if}/>
-                    {/if}
+                    {/if} 
                 {/block}
 
                 {* E-Mail *}

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/sitemap_index_xml/entry.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/sitemap_index_xml/entry.tpl
@@ -1,0 +1,4 @@
+    <sitemap>
+        <loc>{link file=$sitemap->getFilename() fullPath}</loc>
+        <lastmod>{$sitemap->getCreated()->format('Y-m-d')}</lastmod>
+    </sitemap>

--- a/Resources/Themes/Frontend/BootstrapBare/frontend/sitemap_index_xml/index.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/sitemap_index_xml/index.tpl
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{strip}
+    {block name="frontend_sitemap_index_xml_index"}
+        {foreach $sitemaps as $sitemap}
+            {include file="frontend/sitemap_index_xml/entry.tpl" sitemap=$sitemap}
+        {/foreach}
+    {/block}
+{/strip}
+</sitemapindex>


### PR DESCRIPTION
Currently document templates are missing completely in base theme which leads to an error in bootstrap theme and child themes:

> Unable to load template snippet 'documents/index_ls.tpl' in engine/Library/Smarty/sysplugins/smarty_internal_templatebase.php on line 127

I simply copied the templates from Bare theme now.