### PR TITLE
Fix hiding of categories in main navigation

### DIFF
--- a/Resources/Themes/Frontend/BootstrapBare/frontend/plugins/menu/mega-menu.tpl
+++ b/Resources/Themes/Frontend/BootstrapBare/frontend/plugins/menu/mega-menu.tpl
@@ -3,7 +3,7 @@
         {if $level == 0}
             {block name="frontend_index_navigation_mega_menu_main_settings"}   
                 {foreach from=$categories item=category}
-                    {if !$category.hidetop}
+                    {if !$category.hideTop}
                         {assign "has_under" "yes"}
                     {/if}
                 {/foreach}
@@ -26,7 +26,7 @@
             {block name="frontend_index_navigation_mega_menu_main_categories"}
                 {foreach from=$categories item=category name=categoryloop}
                     {block name="frontend_index_navigation_mega_menu_main_category"}
-                        {if !$category.hidetop}
+                        {if !$category.hideTop}
                             <div class="main-nav-sub-head{if $category.sub} subs-active{/if}">
                                 <a {if !empty($category.flag)} class="active"{/if} href="{$category.link}">{$category.name}</a>
                             </div>
@@ -80,10 +80,10 @@
                 </div>
             {/if}
         {elseif $level == 1}
-            {if !$category.hidetop}
+            {if !$category.hideTop}
                 <ul class="main-nav-sub-list">
                     {foreach from=$categories item=category}
-                        {if !$category.hidetop}
+                        {if !$category.hideTop}
                             <li {if !empty($category.flag)} class="active"{/if}>
                                 <a href="{$category.link}">
                                     <small>{$category.name}</small>


### PR DESCRIPTION
The variable `$category.hideTop` has a wrong capitalization (`$category.hidetop`) which makes the condition always return true. This way it is completely useless. With this fix, the categories will be correctly hidden from the main navigation.