### PR TITLE
Remove orphaned closing strip tag

### DIFF
--- a/Resources/Themes/Frontend/BootstrapExtension/frontend/detail/abo_commerce/abo_delivery_duration.tpl
+++ b/Resources/Themes/Frontend/BootstrapExtension/frontend/detail/abo_commerce/abo_delivery_duration.tpl
@@ -17,7 +17,7 @@
 							{s name="AboCommerceIntervalSelectWeeks"}Woche(n){/s}
 						{else}
 							{s name="AboCommerceIntervalSelectMonths"}Monat(e){/s}
-						{/if}{/strip}
+						{/if}
 					</option>
 				{/block}
 			{/for}


### PR DESCRIPTION
The `{/strip}` is missing an opening tag. Also it does not matter much in this position.